### PR TITLE
release: version 2.4.0

### DIFF
--- a/huisbot/Models/Huis/HuisPlayer.cs
+++ b/huisbot/Models/Huis/HuisPlayer.cs
@@ -74,11 +74,11 @@ public class HuisPlayer
   public double FLPP { get; private set; }
 
   /// <summary>
-  /// The weighted cognition PP of the player in the rework the player object is from.
+  /// The weighted reading PP of the player in the rework the player object is from.
   /// This skill only exists in some reworks, and therefore may be null.
   /// </summary>
-  [JsonProperty("weighted_cognition_pp")]
-  public double CogPP { get; private set; }
+  [JsonProperty("weighted_reading_pp")]
+  public double ReadingPP { get; private set; }
 
   /// <summary>
   /// The last time the player got updated on Huismetbenen.

--- a/huisbot/Models/Huis/HuisRework.cs
+++ b/huisbot/Models/Huis/HuisRework.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using static System.Net.WebRequestMethods;
 
 namespace huisbot.Models.Huis;
 
@@ -7,6 +8,11 @@ namespace huisbot.Models.Huis;
 /// </summary>
 public class HuisRework
 {
+  /// <summary>
+  /// The rework ID of the live pp system.
+  /// </summary>
+  public const int LiveId = 1;
+
   /// <summary>
   /// The internal id of the rework. 1 is always the live pp system.
   /// </summary>
@@ -93,14 +99,9 @@ public class HuisRework
   public bool IsConfirmed => ReworkType == "MASTER";
 
   /// <summary>
-  /// The rework ID of the live pp system.
+  /// The URL to the rework on the Huismetbenen website.
   /// </summary>
-  public const int LiveId = 1;
-
-  public override string ToString()
-  {
-    return $"{Id} {Name} ({Code})";
-  }
+  public string Url => $"https://pp.huismetbenen.nl/rankings/info/{Code}";
 
   /// <summary>
   /// The GitHub URL to the commit of the rework.
@@ -150,6 +151,11 @@ public class HuisRework
       3 => "osu!mania",
       _ => "Unknown"
     };
+  }
+
+  public override string ToString()
+  {
+    return $"{Id} {Name} ({Code})";
   }
 
   public override int GetHashCode()

--- a/huisbot/Models/Huis/HuisRework.cs
+++ b/huisbot/Models/Huis/HuisRework.cs
@@ -131,8 +131,8 @@ public class HuisRework
       { IsConfirmed: true } => "✅ Confirmed for next deploy",
       { IsPublic: true, IsActive: true } => "🌐 Public • ✅ Active",
       { IsPublic: true, IsActive: false } => "🌐 Public • 💀 Inactive",
-      { IsPublic: false, IsActive: true } => "🔒 Private • ✅ Active",
-      { IsPublic: false, IsActive: false } => "🔒 Private • 💀 Inactive",
+      { IsPublic: false, IsActive: true } => "🔒 Onion-only • ✅ Active",
+      { IsPublic: false, IsActive: false } => "🔒 Onion-only • 💀 Inactive",
       _ => ReworkType ?? "null"
     };
   }

--- a/huisbot/Models/Huis/HuisRework.cs
+++ b/huisbot/Models/Huis/HuisRework.cs
@@ -35,10 +35,10 @@ public class HuisRework
   /// The URL to the rework on GitHub. This may or may not be targetting the correct branch directly.
   /// </summary>
   [JsonProperty("url")]
-  public string? Url { get; private set; }
+  public string? GitHubUrl { get; private set; }
 
   /// <summary>
-  /// The ID of the current commit. The corresponding GitHub repository can be found in <see cref="Url"/>.
+  /// The ID of the current commit. The corresponding GitHub repository can be found in <see cref="GitHubUrl"/>.
   /// </summary>
   [JsonProperty("commit")]
   public string? Commit { get; private set; }
@@ -103,21 +103,18 @@ public class HuisRework
   }
 
   /// <summary>
-  /// A URL to the commit of the rework.
+  /// The GitHub URL to the commit of the rework.
   /// </summary>
-  public string CommitUrl
+  public string? CommitUrl
   {
     get
     {
-      if (Url is null || Commit is null)
-        return "";
+      // If the GitHub URL or commit is missing (eg. on the historic 2016 rework where no source code is available), return null.
+      if (GitHubUrl is null || Commit is null)
+        return null;
 
-      // If the URL of the rework points to a non-master branch or a commit on the ppy/osu repository, return the URL as-is.
-      if (Url.StartsWith("https://github.com/ppy/osu/tree") && !Url.Contains("/tree/master"))
-        return Url;
-
-      // Otherwise, get the base repository URL (there might be something appending it) and append the commit.
-      return string.Join('/', Url.Split('/').Take(5)) + $"/tree/{Commit}";
+      // Get the base URL of the GitHub repository and append the commit hash.
+      return string.Join('/', GitHubUrl.Split('/').Take(5)) + $"/tree/{Commit}";
     }
   }
 

--- a/huisbot/Models/Huis/HuisSimulationResponse.cs
+++ b/huisbot/Models/Huis/HuisSimulationResponse.cs
@@ -73,10 +73,10 @@ public class HuisSimulationResponse
     public double? FLPP { get; private set; }
 
     /// <summary>
-    /// The cognition PP of the simulated score.
+    /// The reading PP of the simulated score.
     /// </summary>
-    [JsonProperty("cognition")]
-    public double? CogPP { get; private set; }
+    [JsonProperty("reading")]
+    public double? ReadingPP { get; private set; }
   }
 
   /// <summary>

--- a/huisbot/Models/Huis/HuisSimulationResponse.cs
+++ b/huisbot/Models/Huis/HuisSimulationResponse.cs
@@ -106,7 +106,7 @@ public class HuisSimulationResponse
     /// The mods of the score, in the osu-tools format.
     /// </summary>
     [JsonProperty("mods")]
-    public HuisSimulationScoreMod[] OsuMods { get; private set; } = null!;
+    private HuisSimulationScoreMod[] OsuMods { get; set; } = null!;
 
     /// <summary>
     /// The hit statistics of the score.

--- a/huisbot/Program.cs
+++ b/huisbot/Program.cs
@@ -21,7 +21,7 @@ public class Program
   /// <summary>
   /// The version of the application.
   /// </summary>
-  public const string VERSION = "2.3.1";
+  public const string VERSION = "2.4.0";
 
   /// <summary>
   /// The startup time of the application.

--- a/huisbot/Utilities/Discord/Embeds.cs
+++ b/huisbot/Utilities/Discord/Embeds.cs
@@ -85,11 +85,25 @@ internal static class Embeds
   public static Embed Rework(HuisRework rework)
   {
     // Divide the description in multiple parts due to the 1024 character limit.
-    string[] descriptionParts = (rework.Description ?? "") != "" ? rework.Description!.Split("\n\n") : new string[] { "*No description available.*" };
+    List<string> descriptionParts = string.IsNullOrEmpty(rework.Description) ? new List<string>() { "*No description available.*" }
+                                                                             : rework.Description!.Split("\n\n").ToList();
+
+    // If any description parts are still too long, split them further.
+    for (int i = 0; i < descriptionParts.Count; i++)
+      if (descriptionParts[i].Length > 1024)
+      {
+        // Split the description part into two by the first newline.
+        descriptionParts.Insert(i + 1, descriptionParts[i].Split('\n', 2)[1]);
+        descriptionParts[i] = descriptionParts[i].Split('\n', 2)[0];
+
+        // If the part is still too long, truncate it.
+        if (descriptionParts[i].Length > 1024)
+          descriptionParts[i] = descriptionParts[i].Substring(0, 1021) + "...";
+      }
 
     EmbedBuilder embed = BaseEmbed
     .WithTitle($"{rework.Id} {rework.Name} ({rework.Code})")
-    .WithUrl($"https://pp.huismetbenen.nl/rankings/info/{rework.Code}")
+    .WithUrl($"{rework.Url}")
     .AddField("Description", descriptionParts[0]);
 
     // Add the description parts to the embed.
@@ -99,7 +113,7 @@ internal static class Embeds
     string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     embed = embed
       .AddField("Ruleset", rework.RulesetName, true)
-      .AddField("Links", $"[Huismetbenen](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) • {github}", true)
+      .AddField("Links", $"[Huismetbenen]({rework.Url}) • {github}", true)
       .AddField("Status", rework.ReworkTypeString, true);
 
     return embed.Build();
@@ -126,7 +140,7 @@ internal static class Embeds
     // Constructs some more strings for the embed.
     string osuProfile = $"[osu! profile](https://osu.ppy.sh/u/{local.Id})";
     string huisProfile = $"[Huis Profile](https://pp.huismetbenen.nl/player/{local.Id}/{rework.Code})";
-    string huisRework = $"[Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code})";
+    string huisRework = $"[Rework]({rework.Url})";
     string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
 
     return BaseEmbed
@@ -227,7 +241,7 @@ internal static class Embeds
     string stats4 = $"**{Utils.CalculateEstimatedUR(local.Score.Statistics, beatmap, local.Score.Mods):F2}** eUR";
     string visualizer = $"[map visualizer](https://preview.tryz.id.vn/?b={beatmap.Id})";
     string osu = $"[osu! page](https://osu.ppy.sh/b/{beatmap.Id})";
-    string huisRework = $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code})";
+    string huisRework = $"[Huis Rework]({rework.Url})";
     string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
 
     return BaseEmbed
@@ -317,7 +331,7 @@ internal static class Embeds
     List<string> description = new List<string>()
     {
       $"*{rework.Name}*",
-      $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) •  {github}",
+      $"[Huis Rework]({rework.Url}) •  {github}",
       ""
     };
 
@@ -367,7 +381,7 @@ internal static class Embeds
     {
       $"*{rework.Name}*",
       $"[osu! profile](https://osu.ppy.sh/u/{user.Id}) • [Huis Profile](https://pp.huismetbenen.nl/player/{user.Id}/{rework.Code}) • " +
-      $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) • {github}",
+      $"[Huis Rework]({rework.Url}) • {github}",
       ""
     };
 
@@ -421,7 +435,7 @@ internal static class Embeds
     string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     List<string> description = new List<string>()
     {
-      $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) • {github}",
+      $"[Huis Rework]({rework.Url}) • {github}",
       ""
     };
     foreach (HuisPlayer player in players)

--- a/huisbot/Utilities/Discord/Embeds.cs
+++ b/huisbot/Utilities/Discord/Embeds.cs
@@ -448,9 +448,11 @@ internal static class Embeds
     List<string> ppNewStrs = new List<string>();
     foreach (HuisPlayer player in players)
     {
+      double oldPP = Math.Round(player.OldPP);
+      double newPP = Math.Round(player.NewPP);
       playerStrs.Add($"**#{player.Rank?.ToString() ?? "-"}** [{player.Name}](https://osu.ppy.sh/u/{player.Id})");
-      ppOldStrs.Add($"{GetPPDifferenceText(player.OldPP, player.NewPP, true).Split('→')[0].Trim()}");
-      ppNewStrs.Add($"{GetPPDifferenceText(player.OldPP, player.NewPP, true).Split('→')[1].Trim()}");
+      ppOldStrs.Add(oldPP.ToString("#,##0.##"));
+      ppNewStrs.Add($"**{newPP:#,##0.##}pp**" + (oldPP != newPP ? $" ({newPP - oldPP:+#,##0.##;-#,##0.##}pp)" : ""));
     }
 
     // Generate the page information footer.
@@ -512,24 +514,19 @@ internal static class Embeds
   /// </summary>
   /// <param name="oldPP">The old PP.</param>
   /// <param name="newPP">The new PP.</param>
-  /// <param name="thousandSeparator">Bool whether a thousand separator should be applied.</param>
   /// <returns>A string representing the difference between two PP values.</returns>
-  private static string GetPPDifferenceText(double oldPP, double newPP, bool thousandSeparator = false)
+  private static string GetPPDifferenceText(double oldPP, double newPP)
   {
     // Round the PP values, as decimals are irrelevant info and hurts the display flexibility.
     oldPP = Math.Round(oldPP);
     newPP = Math.Round(newPP);
 
-    // Apply a thousand operator if requested.
-    string oldPPStr = oldPP.ToString(thousandSeparator ? "#,##0.##" : "0.##");
-    string newPPStr = newPP.ToString(thousandSeparator ? "#,##0.##" : "0.##");
-
     // If the PP do not differ, simply return the PP value.
     if (newPP == oldPP)
-      return $"**{newPPStr}pp**";
+      return $"**{oldPP:0.##}pp**";
 
     // Otherwise return the difference string.
-    return $"{oldPPStr}pp → **{newPPStr}pp** ({newPP - oldPP:+#,##0.##;-#,##0.##}pp)";
+    return $"{oldPP:0.##}pp → **{newPP:0.##}pp** ({newPP - oldPP:+#,##0.##;-#,##0.##}pp)";
   }
 
   /// <summary>

--- a/huisbot/Utilities/Discord/Embeds.cs
+++ b/huisbot/Utilities/Discord/Embeds.cs
@@ -144,8 +144,8 @@ internal static class Embeds
     ppStr += $"\n▸ **Acc**: {GetPPDifferenceText(live.AccPP, local.AccPP)}";
     if (local.FLPP + live.FLPP > 0)
       ppStr += $"\n▸ **FL**: {GetPPDifferenceText(live.FLPP, local.FLPP)}";
-    if (local.CogPP + live.CogPP > 0)
-      ppStr += $"\n▸ **Cog**: {GetPPDifferenceText(live.CogPP, local.CogPP)}";
+    if (local.ReadingPP + live.ReadingPP > 0)
+      ppStr += $"\n▸ **Read**: {GetPPDifferenceText(live.ReadingPP, local.ReadingPP)}";
 
     // Constructs some more strings for the embed.
     string osuProfile = $"[osu! profile](https://osu.ppy.sh/u/{local.Id})";
@@ -233,8 +233,8 @@ internal static class Embeds
     ppStr += $"\n▸ **Acc**: {GetPPDifferenceText(reference.PerformanceAttributes.AccPP, local.PerformanceAttributes.AccPP)}";
     if (local.PerformanceAttributes.FLPP is not null)
       ppStr += $"\n▸ **FL**: {GetPPDifferenceText(reference.PerformanceAttributes.FLPP ?? 0, local.PerformanceAttributes.FLPP.Value)}";
-    if (local.PerformanceAttributes.CogPP is not null)
-      ppStr += $"\n▸ **Cog**: {GetPPDifferenceText(reference.PerformanceAttributes.CogPP ?? 0, local.PerformanceAttributes.CogPP.Value)}";
+    if (local.PerformanceAttributes.ReadingPP is not null)
+      ppStr += $"\n▸ **Read**: {GetPPDifferenceText(reference.PerformanceAttributes.ReadingPP ?? 0, local.PerformanceAttributes.ReadingPP.Value)}";
 
     // Construct some more strings for the embed.
     double refDiff = reference.DifficultyAttributes.DifficultyRating;

--- a/huisbot/Utilities/Discord/Embeds.cs
+++ b/huisbot/Utilities/Discord/Embeds.cs
@@ -96,7 +96,7 @@ internal static class Embeds
     foreach (string part in descriptionParts.Skip(1))
       embed = embed.AddField("\u200B", part);
 
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     embed = embed
       .AddField("Ruleset", rework.RulesetName, true)
       .AddField("Links", $"[Huismetbenen](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) • {github}", true)
@@ -127,7 +127,7 @@ internal static class Embeds
     string osuProfile = $"[osu! profile](https://osu.ppy.sh/u/{local.Id})";
     string huisProfile = $"[Huis Profile](https://pp.huismetbenen.nl/player/{local.Id}/{rework.Code})";
     string huisRework = $"[Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code})";
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
 
     return BaseEmbed
       .WithColor(new Color(0x58A1FF))
@@ -228,7 +228,7 @@ internal static class Embeds
     string visualizer = $"[map visualizer](https://preview.tryz.id.vn/?b={beatmap.Id})";
     string osu = $"[osu! page](https://osu.ppy.sh/b/{beatmap.Id})";
     string huisRework = $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code})";
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
 
     return BaseEmbed
       .WithColor(new Color(0x4061E9))
@@ -313,7 +313,7 @@ internal static class Embeds
   public static Embed ScoreRankings(HuisScore[] allScores, HuisRework rework, Sort sort, int page)
   {
     // Generate the embed description.
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     List<string> description = new List<string>()
     {
       $"*{rework.Name}*",
@@ -362,7 +362,7 @@ internal static class Embeds
   public static Embed TopPlays(OsuUser user, HuisScore[] rawScores, HuisScore[] sortedScores, HuisRework rework, Sort sort, int page)
   {
     // Generate the embed description.
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     List<string> description = new List<string>()
     {
       $"*{rework.Name}*",
@@ -418,7 +418,7 @@ internal static class Embeds
     HuisPlayer[] players = allPlayers.Skip((page - 1) * 20).Take(20).ToArray();
 
     // Generate the embed description.
-    string github = rework.CommitUrl is "" ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
+    string github = rework.CommitUrl is null ? "Source unavailable" : $"[Source]({rework.CommitUrl})";
     List<string> description = new List<string>()
     {
       $"[Huis Rework](https://pp.huismetbenen.nl/rankings/info/{rework.Code}) • {github}",


### PR DESCRIPTION
# Features
- 8e609b1e3749cb7579b73e9cd5f044cc1ce4a342 Added the ability to navigate through embeds with pages via Discord message components
# Changes
- 8e609b1e3749cb7579b73e9cd5f044cc1ce4a342 Improved the embed design of player rankings (CURRENTLY BREAKS MOBILE)
- 646397144fa0910ebb76991b8af2f6a4c1959960 The source code URLs for reworks have been improved to be more precise and useful
- 9b76b2b5ef36f50f9965d411c30adfb9096a3666 "private" reworks are now called "onion-only"
- 5a94bbd79f6d6465dc23a8a4d16462c3803eca4e Improved efforts to display the rework description properly
- 94659c84b7cdef3d97dea8d0039d0866bfa39c42 To reflect Huismetbenen changes, "cognition" has been renamed to "reading"