### PR TITLE
release: version 2.8.1

### DIFF
--- a/huisbot/Models/Huis/HuisScore.cs
+++ b/huisbot/Models/Huis/HuisScore.cs
@@ -126,6 +126,12 @@ public class HuisScore
     /// </summary>
     [JsonProperty("creator_name")]
     public string Creator { get; private set; } = null!;
+
+    /// <summary>
+    /// The maximum combo of the beatmap.
+    /// </summary>
+    [JsonProperty("max_combo")]
+    public int MaxCombo { get; private set; }
   }
 
   /// <summary>

--- a/huisbot/Models/Osu/OsuMod.cs
+++ b/huisbot/Models/Osu/OsuMod.cs
@@ -18,7 +18,23 @@ public class OsuMod(string acronym)
   /// The mod settings.
   /// </summary>
   [JsonProperty("settings")]
-  public Dictionary<string, object> Settings { get; private set; } = [];
+  public Dictionary<string, object> Settings
+  {
+    get => field;
+    set
+    {
+      field = [];
+
+      // Ensure that all number values are doubles for better handling of object-unboxing.
+      foreach (KeyValuePair<string, object> setting in value)
+        field[setting.Key] = setting.Value switch
+        {
+          int @int => (double)@int,
+          long @long => (double)@long,
+          _ => setting.Value
+        };
+    }
+  } = [];
 
   /// <summary>
   /// Returns the value by the specified settings key, or null if the setting does not exist.

--- a/huisbot/Modules/CSharpRepl.cs
+++ b/huisbot/Modules/CSharpRepl.cs
@@ -76,7 +76,7 @@ public class CSharpReplCommandModule(IServiceProvider services, Database databas
     // Ensure that the user is the owner of the application.
     if (Context.User.Id != Discord.BotOwnerId)
     {
-      await RespondAsync(embed: Embeds.Error("Only the owner of the application is permitted to use this command."));
+      await FollowupAsync(embed: Embeds.Error("Only the owner of the application is permitted to use this command."));
       return;
     }
 
@@ -96,7 +96,7 @@ public class CSharpReplCommandModule(IServiceProvider services, Database databas
       Database = database
     };
 
-    await RespondAsync(embed: Embeds.Neutral("Executing code..."));
+    await FollowupAsync(embed: Embeds.Neutral("Executing code..."));
 
     ScriptState<object> state;
     try

--- a/huisbot/Modules/Huis/Rankings.cs
+++ b/huisbot/Modules/Huis/Rankings.cs
@@ -73,7 +73,7 @@ public class RankingsCommandModule(IServiceProvider services) : ModuleBase(servi
   {
     await DeferAsync();
 
-    if (await GetSortAsync(sortId, Sort.RankingPlayers) is not Sort sort) return;
+    if (await GetSortAsync(sortId, Sort.RankingScores) is not Sort sort) return;
     if (await GetReworkAsync(reworkId) is not HuisRework rework) return;
     if (await GetScoreRankingsAsync(rework.Id, sort) is not HuisScore[] scores) return;
 

--- a/huisbot/Modules/Huis/TopPlays.cs
+++ b/huisbot/Modules/Huis/TopPlays.cs
@@ -56,12 +56,10 @@ public class TopPlaysCommandModule(IServiceProvider services) : ModuleBase(servi
     if (await GetTopPlaysAsync(user, rework.Id, scoreType) is not HuisScore[] scores) return;
 
     // If filtering for top ranks is enabled, only include the best score on each beatmap.
-    // For that, sort the scores by local PP and for every beatmap in those scores, pick the first occuring score with that beatmap. 
+    // For that, for every beatmap in those scores, pick the first occuring score with that beatmap when sorting by local PP. 
     if (filterTopRanks)
-      scores = scores.OrderByDescending(x => x.Values.LocalPP)
-                     .Select(x => x.Beatmap.Id)
-                     .Distinct()
-                     .Select(id => scores.First(x => x.Beatmap.Id == id))
+      scores = scores.Select(x => x.Beatmap.Id).Distinct()
+                     .Select(id => scores.OrderByDescending(x => x.Values.LocalPP).First(x => x.Beatmap.Id == id))
                      .ToArray();
 
     // Apply the sorting to the scores, since this is done inside the browser on Huis and has no API parameter.

--- a/huisbot/Modules/Huis/TopPlays.cs
+++ b/huisbot/Modules/Huis/TopPlays.cs
@@ -31,13 +31,15 @@ public class TopPlaysCommandModule(IServiceProvider services) : ModuleBase(servi
   public async Task HandleScoreAsync(
     [Summary("rework", "An identifier for the rework. This can be it's ID, internal code or autocompleted name.")]
     [Autocomplete(typeof(ReworkAutocompleteHandler))] string reworkId,
-    [Summary("user", "The osu! ID or name of the player. Optional, defaults to your linked osu! user.")] string? userId = null,
+    [Summary("user", "The osu! ID or name of the user. Optional, defaults to your linked osu! user.")] string? userId = null,
     [Summary("type", "The type of top scores to return (top scores, flashlight scores or pinned scores).")]
     [Choice("Top Scores", "topranks")] [Choice("Flashlight Scores", "flashlight")]
     [Choice("Pinned Scores", "pinned")] string scoreType = "topranks",
     [Summary("page", "The page of the scores. 1 page displays 10 scores.")][MinValue(1)] int page = 1,
     [Summary("sort", "The sorting for the scores. Defaults to sort by Local PP.")]
-    [Autocomplete(typeof(ProfileScoresSortAutocomplete))] string sortId = "local_pp_desc")
+    [Autocomplete(typeof(ProfileScoresSortAutocomplete))] string sortId = "local_pp_desc",
+    [Summary("filterTopRanks", "Bool whether only the top score on each beatmap should be returned. Defaults to true.")]
+    bool filterTopRanks = true)
   {
     await DeferAsync();
 
@@ -52,6 +54,15 @@ public class TopPlaysCommandModule(IServiceProvider services) : ModuleBase(servi
     if (await GetReworkAsync(reworkId) is not HuisRework rework) return;
     if (await GetOsuUserAsync(userId) is not OsuUser user) return;
     if (await GetTopPlaysAsync(user, rework.Id, scoreType) is not HuisScore[] scores) return;
+
+    // If filtering for top ranks is enabled, only include the best score on each beatmap.
+    // For that, sort the scores by local PP and for every beatmap in those scores, pick the first occuring score with that beatmap. 
+    if (filterTopRanks)
+      scores = scores.OrderByDescending(x => x.Values.LocalPP)
+                     .Select(x => x.Beatmap.Id)
+                     .Distinct()
+                     .Select(id => scores.First(x => x.Beatmap.Id == id))
+                     .ToArray();
 
     // Apply the sorting to the scores, since this is done inside the browser on Huis and has no API parameter.
     Func<HuisScore, double> selector = sort.Code switch

--- a/huisbot/Program.cs
+++ b/huisbot/Program.cs
@@ -24,7 +24,7 @@ public class Program
   /// <summary>
   /// The version of the application.
   /// </summary>
-  public const string VERSION = "2.8.0";
+  public const string VERSION = "2.8.1";
 
   public static async Task Main(string[] args)
   {

--- a/huisbot/Services/DiscordService.cs
+++ b/huisbot/Services/DiscordService.cs
@@ -42,8 +42,8 @@ public class DiscordService(DiscordSocketClient client, ILogger<DiscordService> 
     RestApplication app = await Client.GetApplicationInfoAsync();
     BotOwnerId = app.Team is null ? app.Owner.Id : app.Team.OwnerUserId;
 
-    Logger.LogInformation("Fetched {Emotes} application emotes.", ApplicationEmotes.Length);
-    Logger.LogInformation("Fetched bot owner ID: {Id}.", BotOwnerId);
+    Logger.LogInformation("Fetched {Amount} application emotes: {Emotes}", ApplicationEmotes.Length, string.Join(", ", ApplicationEmotes.Select(x => x.Name)));
+    Logger.LogInformation("Fetched bot owner ID: {Id}", BotOwnerId);
   }
 
   /// <summary>
@@ -51,7 +51,7 @@ public class DiscordService(DiscordSocketClient client, ILogger<DiscordService> 
   /// </summary>
   public async Task<(int GuildInstalls, int UserInstalls)> GetInstallCountsAsync()
   {
-    await Client.WaitForReadyAsync(new CancellationToken());
+    await Client.WaitForReadyAsync(CancellationToken.None);
     RestApplication app = await Client.GetApplicationInfoAsync();
     return (app.ApproximateGuildCount ?? -1, app.ApproximateUserInstallCount ?? -1);
   }

--- a/huisbot/Services/EmbedService.cs
+++ b/huisbot/Services/EmbedService.cs
@@ -390,7 +390,7 @@ public class EmbedService(DiscordService discord)
       int placementDiff = rawScores.OrderByDescending(x => x.Values.LivePP).ToList().IndexOf(score) + 1 - placement;
       string placementStr = $"**#{placement}**" + (placementDiff != 0 ? $" ({placementDiff:+#;-#;0})" : "");
 
-      description.Add($"{placementStr} [{FormatScoreText(score)}](https://osu.ppy.sh/b/{score.Beatmap.Id})");
+      description.Add($"{placementStr} [{FormatScoreText(score)}](https://osu.ppy.sh/scores/{score.ScoreId})");
       description.Add($"▸ {GetPPDifferenceText(score.Values.LivePP, score.Values.LocalPP)} ▸ {score.Accuracy:N2}% {score.MaxCombo}x " +
                       $"▸ {score.Statistics.Count100} {Emojis["100"]} {score.Statistics.Count50} {Emojis["50"]} {score.Statistics.Misses} {Emojis["miss"]}");
     }
@@ -536,7 +536,7 @@ public class EmbedService(DiscordService discord)
     if ($"{title} [{version}]".Length > 60)
       title = $"{title[..27]}...";
 
-    return $"{title} [{version}] {score.Mods}".TrimEnd(' ');
+    return $"{title} [{version}]{score.Mods.PlusString}";
   }
 
   #endregion

--- a/huisbot/Services/EmbedService.cs
+++ b/huisbot/Services/EmbedService.cs
@@ -391,8 +391,7 @@ public class EmbedService(DiscordService discord)
       string placementStr = $"**#{placement}**" + (placementDiff != 0 ? $" ({placementDiff:+#;-#;0})" : "");
 
       description.Add($"{placementStr} [{FormatScoreText(score)}](https://osu.ppy.sh/scores/{score.ScoreId})");
-      description.Add($"▸ {GetPPDifferenceText(score.Values.LivePP, score.Values.LocalPP)} ▸ {score.Accuracy:N2}% {score.MaxCombo}x " +
-                      $"▸ {score.Statistics.Count100} {Emojis["100"]} {score.Statistics.Count50} {Emojis["50"]} {score.Statistics.Misses} {Emojis["miss"]}");
+      description.Add($"▸ {GetPPDifferenceText(score.Values.LivePP, score.Values.LocalPP)} ▸ {score.Accuracy:N2}% {score.MaxCombo}/{score.Beatmap.MaxCombo}x ▸ {score.Statistics.Count100} {Emojis["100"]} {score.Statistics.Count50} {Emojis["50"]} {score.Statistics.Misses} {Emojis["miss"]}");
     }
 
     description.Add($"\n*Displaying scores {page * SCORES_PER_PAGE - (SCORES_PER_PAGE - 1)}-" +
@@ -470,10 +469,8 @@ public class EmbedService(DiscordService discord)
     int scorePlacement = (page - 1) * SCORES_PER_PAGE; // Keep track of the placement of the score
     foreach (HuisScore score in scores.Skip((page - 1) * SCORES_PER_PAGE).Take(SCORES_PER_PAGE))
     {
-      description.Add($"**#{++scorePlacement}** [{score.User.Name}](https://osu.ppy.sh/u/{score.User.Id}) on " +
-                      $"[{FormatScoreText(score)}](https://osu.ppy.sh/b/{score.Beatmap.Id})");
-      description.Add($"▸ {GetPPDifferenceText(score.Values.LivePP, score.Values.LocalPP)} ▸ {score.Accuracy:N2}% {score.MaxCombo}x " +
-                      $"▸ {score.Statistics.Count100} {Emojis["100"]} {score.Statistics.Count50} {Emojis["50"]} {score.Statistics.Misses} {Emojis["miss"]}");
+      description.Add($"**#{++scorePlacement}** [{score.User.Name}](https://osu.ppy.sh/u/{score.User.Id}) on [{FormatScoreText(score)}](https://osu.ppy.sh/scores/{score.ScoreId})");
+      description.Add($"▸ {GetPPDifferenceText(score.Values.LivePP, score.Values.LocalPP)} ▸ {score.Accuracy:N2}% {score.MaxCombo}/{score.Beatmap.MaxCombo}x ▸ {score.Statistics.Count100} {Emojis["100"]} {score.Statistics.Count50} {Emojis["50"]} {score.Statistics.Misses} {Emojis["miss"]}");
     }
 
     description.Add($"\n*Displaying scores {page * SCORES_PER_PAGE - (SCORES_PER_PAGE - 1)}-" +

--- a/huisbot/huisbot.csproj
+++ b/huisbot/huisbot.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Development;Release</Configurations>


### PR DESCRIPTION
# Features
- 8c622cea3f05cdd7caecea123b8ddb447dfd35a8 da0c5a45f14aecfe55fc9440371e4e7005bc6813 Added parameter `/topplays` command for filtering for top ranks only (enabled by default)
- e513ae8f8f3f23c160812ba800ee106dd93bdcab Added max combo to `/topplays` and `/rankings score` commands

# Changes
- d7f12c189d555406af47420b668cf05f7cdfca8f Replaced beatmap URL with score URL in the `/topplays` command embed

# Bug Fixes
- eada3ca129c7b9d2ab19ba3c45fa5b50590394b7 Fixed `/csharprepl` using `RespondAsync` instead of `FollowupAsync` despite deferring
- 73042d1bf9f634fae5e102a979aeecc5690687bd Ensure number values in mod settings are always doubles to fix invalid object unboxing

# Code Quality
- 3edee05cbcfa6d70159b9ff29ce4b5b27707d0e6 Updated to the C# preview version